### PR TITLE
[odoo-panama][FIX][l10n_pa_hr_loan] changed the value of key of the data in l10n_pa_hr_loan, this to fixed the integrity error

### DIFF
--- a/l10n_pa_hr_loan/data/hr_loan_data.xml
+++ b/l10n_pa_hr_loan/data/hr_loan_data.xml
@@ -6,7 +6,7 @@
     of December
 -->
     <record id="ir_config_december" model="ir.config_parameter">
-        <field name="key">hr_loan.month_exception</field>
+        <field name="key">l10n_pa_hr_loan.month_exception</field>
         <field name="value">12</field>
     </record>
   </data>

--- a/l10n_pa_hr_loan/data/hr_loan_data.xml
+++ b/l10n_pa_hr_loan/data/hr_loan_data.xml
@@ -5,8 +5,8 @@
     ir.config_parameter for the calculation of hr loan ommigin the month
     of December
 -->
-    <record id="ir_config_december" model="ir.config_parameter">
-        <field name="key">l10n_pa_hr_loan.month_exception</field>
+    <record id="hr_loan.ir_config_december_demo" model="ir.config_parameter">
+        <field name="key">hr_loan.month_exception</field>
         <field name="value">12</field>
     </record>
   </data>


### PR DESCRIPTION
[odoo-panama][FIX][l10n_pa_hr_loan] changed the value of key of the data in l10n_pa_hr_loan, this to fixed the integrity error
