### PR TITLE
[IMP] l10n_pa_localization: in order to solves vauxoo/yoytec#1622

### DIFF
--- a/l10n_pa_localization/view/res_partner_view.xml
+++ b/l10n_pa_localization/view/res_partner_view.xml
@@ -36,7 +36,6 @@
                                     <div class="address_format">
                                         <field name="city" placeholder="City" style="width: 40%%"/>
                                         <field name="state_id" class="oe_no_button" placeholder="State" style="width: 37%%" options='{"no_open": True}' on_change="onchange_state(state_id)"/>
-                                        <field name="zip" placeholder="ZIP" style="width: 20%%"/>
                                     </div>
                                     <field name="country_id" placeholder="Country" class="oe_no_button" options='{"no_open": True}'/>
                                 </div>


### PR DESCRIPTION
we need to deprecate in form view 'zip' field, because:
1. This field is not used in l10n_pa
2. There is incongruence between this view and the view form created
by format_address in 'panama' country that is causing error in kanban
